### PR TITLE
Tools: add cron script to refresh mwgg_igdb (ao) and upgrade deps

### DIFF
--- a/tools/cron_update_mwgg_igdb_ao.sh
+++ b/tools/cron_update_mwgg_igdb_ao.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cron-friendly: hard-reinstall game_index/ao, verify import, then upgrade all deps (+ transitive) via uv.
+#
+# Crontab example (every day at 04:00):
+#   0 4 * * *  /path/to/MultiworldGG/tools/cron_update_mwgg_igdb_ao.sh >> /var/log/mwgg_igdb_ao.log 2>&1
+
+set -euo pipefail
+
+# ---- Config: edit these to match your environment ----------------------------
+REPO_ROOT="${MWGG_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+MWGG_VENV="${MWGG_VENV:-/path/to/mwgg_venv}"        # <-- set this to your specific mwgg_venv
+REQUIREMENTS="${MWGG_REQUIREMENTS:-$REPO_ROOT/requirements.txt}"
+# ------------------------------------------------------------------------------
+
+VENV_PY="$MWGG_VENV/bin/python"
+AO_SRC="$REPO_ROOT/game_index/ao"
+
+log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*"; }
+
+[[ -x "$VENV_PY"     ]] || { log "ERROR: venv python not found at $VENV_PY"; exit 1; }
+[[ -d "$AO_SRC"      ]] || { log "ERROR: game_index/ao not found at $AO_SRC"; exit 1; }
+[[ -f "$REQUIREMENTS" ]] || { log "ERROR: requirements file not found at $REQUIREMENTS"; exit 1; }
+
+command -v uv >/dev/null || { log "ERROR: 'uv' not on PATH"; exit 1; }
+
+log "Activating venv: $MWGG_VENV"
+# shellcheck disable=SC1091
+source "$MWGG_VENV/bin/activate"
+export VIRTUAL_ENV="$MWGG_VENV"
+
+log "Step 1/3: force-reinstalling mwgg_igdb (ao) from $AO_SRC"
+uv pip install --python "$VENV_PY" --force-reinstall --no-deps --upgrade "$AO_SRC"
+
+log "Step 2/3: verifying import"
+"$VENV_PY" -c 'from mwgg_igdb import GAMES_DATA, GameIndex; print(f"mwgg_igdb OK: {len(GAMES_DATA)} games")'
+
+log "Step 3/3: upgrading project deps (+ transitive) from $REQUIREMENTS"
+# --upgrade resolves to latest compatible versions for everything in the file,
+# and the resolver pulls in (and upgrades) transitive dependencies as a matter
+# of course. --reinstall forces a clean install so stale transitive pins from
+# a prior partial run don't linger.
+uv pip install --python "$VENV_PY" --upgrade --reinstall -r "$REQUIREMENTS"
+
+log "Done."


### PR DESCRIPTION
## What is this fixing or adding?

Adds `tools/cron_update_mwgg_igdb_ao.sh`, a small cron-friendly script that:

1. **Force-reinstalls `mwgg_igdb` from `game_index/ao`** into a configured `mwgg_venv` (`uv pip install --force-reinstall --no-deps --upgrade`).
2. **Verifies the import** (`from mwgg_igdb import GAMES_DATA, GameIndex`) so a broken install surfaces in cron mail instead of failing silently at next launch.
3. **Upgrades project requirements** with `uv pip install --upgrade --reinstall -r requirements.txt`, which pulls in the latest compatible versions for the listed packages and their transitive deps. `--reinstall` keeps stale pins from prior partial runs from lingering.

Config is via env vars at the top of the script (`MWGG_REPO_ROOT`, `MWGG_VENV`, `MWGG_REQUIREMENTS`); the header comment includes a sample crontab line.

Note: nothing else in the repo currently installs the *ao* variant — `build_exe.py` reinstalls *sixteen*. If a build runs after this cron, it will overwrite the ao install. Worth keeping in mind when scheduling.

## How was this tested?

Static review only — script is shell-only and has not been executed against a live venv. Manual smoke test on a target host is recommended before scheduling: run with `MWGG_VENV` pointed at the real venv and confirm all three steps succeed.

## If this makes graphical changes, please attach screenshots.

N/A — tooling only.